### PR TITLE
Ability to modify existing yum/dnf repository/AlmaLinux 9.x fix

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -11,6 +11,9 @@
 - name: Install repo
   ansible.builtin.import_tasks: repo.yaml
 
+- name: Modify repo
+- ansible.builtin.import_tasks: modify_repo.yaml
+
 - name: Install packages
   ansible.builtin.import_tasks: packages.yaml
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -12,7 +12,7 @@
   ansible.builtin.import_tasks: repo.yaml
 
 - name: Modify repo
-- ansible.builtin.import_tasks: modify_repo.yaml
+  ansible.builtin.import_tasks: modify_repo.yaml
 
 - name: Install packages
   ansible.builtin.import_tasks: packages.yaml

--- a/tasks/modify_repo.yaml
+++ b/tasks/modify_repo.yaml
@@ -1,0 +1,10 @@
+---
+- name: "modify repo"
+  community.general.ini_file:
+    path:       "/etc/yum.repos.d/{{ item.repo_name }}.repo"
+    section:    "{{ item.section }}"
+    option:     "{{ item.option }}"
+    value:      "{{ item.value }}"
+    create:     no
+  loop: "{{ modify_repo }}"
+  when: modify_repo is defined

--- a/vars/AlmaLinux-9.yaml
+++ b/vars/AlmaLinux-9.yaml
@@ -1,0 +1,15 @@
+---
+modify_repo:
+  - repo_name: almalinux-crb
+    section: "crb"
+    option: enabled
+    value: 1
+
+common_packages:
+  - epel-release
+  - centos-release-openstack-yoga
+  - wget
+  - git
+  - vim-enhanced
+  - nc
+  - bind-utils


### PR DESCRIPTION
Ansible has no existing mechansim to actually enable an existing (non ansible created) yum repository, so when one needs to enable for example the powertools repository, the recommended way forward is ini_file method. In this case python3-virtualenv is dependent on a package from the powertools repository (which is disabled by default) when running AlmaLinux 9.