### PR TITLE
Making 'module_hotfixes' an optional parameter which is omitted if not set

### DIFF
--- a/tasks/repo.yaml
+++ b/tasks/repo.yaml
@@ -9,7 +9,7 @@
     enabled: "{{ item.value.enable | default('yes') }}"
     gpgkey: "{{ item.value.gpgkey | default(omit) }}"
     gpgcheck: "{{ item.value.gpgcheck | default('yes') }}"
-    module_hotfixes: "{{ item.value.module_hotfixes | default('yes') }}"
+    module_hotfixes: "{{ item.value.module_hotfixes | default(omit) }}"
     description: "{{ item.value.description | default(item.key) }}"
   with_dict: "{{ custom_yum_repos | default({}) }}"
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
The parameter was introduced in ansible-core 2.11, maintaining backward compatibility by not defaulting to 'yes'.