### PR TITLE
Configure cron jobs using the custom_cronjob dictionary

### DIFF
--- a/tasks/cronjobs.yaml
+++ b/tasks/cronjobs.yaml
@@ -1,0 +1,13 @@
+---
+- name: Setup cron jobs
+  ansible.builtin.cron:
+    name: "{{ item.value.name | default(item.key) }}"
+    user: "{{ item.value.user | default('root') }}"
+    minute: "{{ item.value.minute | default('*') }}"
+    hour: "{{ item.value.hour | default('*') }}"
+    day: "{{ item.value.day | default('*') }}"
+    month: "{{ item.value.month | default('*') }}"
+    weekday: "{{ item.value.weekday | default('*') }}"
+    job: "{{ item.value.job }}"
+    state: "{{ item.value.state | default('present') }}"
+  with_dict: "{{ custom_cronjobs | default({}) }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -23,3 +23,7 @@
 - name: Manage volume
   ansible.builtin.import_tasks: volume.yaml
   when: manage_volume | bool
+
+- name: Setup cronjobs
+  ansible.builtin.import_tasks: cronjobs.yaml
+  tags: cronjobs


### PR DESCRIPTION
This pull request introduces the setup of cron jobs through Ansible playbooks. The changes include creating a new cron job task and integrating it into the main task file.

Changes to cron job setup:

* [`tasks/cronjobs.yaml`](diffhunk://#diff-cc78a941555368297d13cf8351f861c3448bc7bb31a111cac759c9335ab65772R1-R13): Added a new task to set up cron jobs using the `ansible.builtin.cron` module, with parameters for job scheduling and state management.

Integration into main tasks:

* [`tasks/main.yaml`](diffhunk://#diff-4c8ff70031d9ec638847c22d4861e71661e715158f539a3ecd99fa85a305d098R26-R28): Included the new cron job setup task by importing `cronjobs.yaml` in the main task file.