### PR TITLE
Add logrotate configration with custom_logrotate dict

### DIFF
--- a/tasks/logrotate.yaml
+++ b/tasks/logrotate.yaml
@@ -1,0 +1,16 @@
+---
+- name: Logrotate configuration
+  ansible.builtin.copy:
+    dest: "{{ custom_logrotate.dest }}"
+    content: |
+      {{ custom_logrotate.log_file }} {
+          size {{ custom_logrotate.size }}
+          rotate {{ custom_logrotate.rotate }}
+          {% if custom_logrotate.compress %}  compress{% endif %}
+          {% if custom_logrotate.missingok %}  missingok{% endif %}
+          {% if custom_logrotate.notifempty %}  notifempty{% endif %}
+      }
+    owner: root
+    group: root
+    mode: '0644'
+  when: custom_logrotate is defined

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -20,6 +20,10 @@
 - name: Setup services
   ansible.builtin.import_tasks: service.yaml
 
+- name: Setup logrotate configuration
+  ansible.builtin.import_tasks: logrotate.yaml
+  tags: logrotate
+
 - name: Setup systemd cleanup configuration
   ansible.builtin.import_tasks: systemd_cleanup_rules.yaml
   tags: systemd-cleanup-rules


### PR DESCRIPTION
Adds a logrotate configuration task using the custom_logrotate dict.
This allows flexible log rotation settings by defining the log file, size, rotation count, and options like compress, missingok, and notifempty via variables.
The task is only applied if custom_logrotate is defined.